### PR TITLE
no age shaming

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -6,7 +6,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "1",
   "content_scripts": [{
     "matches": ["https://leetcode.com/*"],
     "js": ["content.js"]}


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)